### PR TITLE
Introduction of RoughMets and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 token.json
 credentials.json
-Staging
+Staging*
 .DS_Store
 gdrive_secret.yml

--- a/templates/livery_section.j2
+++ b/templates/livery_section.j2
@@ -1,0 +1,8 @@
+
+  Section "{{ livery["livery_base_dirname"] }}"
+    SetOutPath "$INSTDIR\{{ livery["dcs_airframe_codename"] }}"
+    File /r "{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
+    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
+    File /r "{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
+    {%- endfor %}
+  SectionEnd

--- a/templates/removal.j2
+++ b/templates/removal.j2
@@ -1,0 +1,5 @@
+
+    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
+    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
+    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
+    {%- endfor %}

--- a/templates/rs-liveries.nsi.j2
+++ b/templates/rs-liveries.nsi.j2
@@ -35,15 +35,18 @@ VIProductVersion ${VERSION}
 OutFile "RS Liveries.exe"
 
 ; Request application privileges for Windows Vista
-RequestExecutionLevel user
+RequestExecutionLevel admin
 
 ; Build Unicode installer
 Unicode True
 
 Var Dialog
 Var Label
+Var LabelBrowse
 Var Pilot
 Var PilotSelected
+Var ProgramFilesDir
+Var BrowseButton
 
 
 Function nsDialogsPage
@@ -56,28 +59,53 @@ Function nsDialogsPage
 
 	${NSD_CreateLabel} 0 0 100% 12u "Who are you?"
 	Pop $Label
-	${NSD_CreateDropList} 0 20 100% 12u ""
+	
+  ${NSD_CreateDropList} 0 20 100% 12u ""
 	Pop $Pilot
   ${NSD_CB_AddString} $Pilot "-- RS SQUAD BUT NOT IN LIST --"
   ${NSD_CB_AddString} $Pilot "-- STREAMER / YOUTUBER --"
   {%- for pilot in pilots %}
   ${NSD_CB_AddString} $Pilot "{{ pilot }}"
   {%- endfor %}
+  ${NSD_CB_SelectString} $Pilot "-- RS SQUAD BUT NOT IN LIST --"
+	
+  ${NSD_CreateLabel} 0 60 100% 12u "Please select the install directory of DCS"
+	Pop $LabelBrowse
+  
+  ${NSD_CreateBrowseButton} 0 80 100% 12u "$ProgramFilesDir"
+  Pop $BrowseButton
+  ${NSD_OnClick} $BrowseButton OnDirBrowse
 
 	nsDialogs::Show
 FunctionEnd
 
+Function OnDirBrowse
+    ${NSD_GetText} $BrowseButton $0
+    nsDialogs::SelectFolderDialog "Please select the install directory of DCS" "$0" 
+    Pop $0
+    ${If} $0 != error
+        ${NSD_SetText} $BrowseButton "$0"
+    ${EndIf}
+FunctionEnd
+
 Function nsDialogsPageLeave
 	${NSD_GetText} $Pilot $PilotSelected
+  ${NSD_GetText} $BrowseButton $ProgramFilesDir
 FunctionEnd
 
 Function .onInit
   # Detect which Save/liveries directory to use. If multiple exist, use the most bottom one from this list.
-  ${If} ${FileExists} "$PROFILE\Saved Games\DCS"
+  ${If} ${FileExists} "$PROFILE\Saved Games\DCS.openbeta"
     StrCpy $InstDir "$PROFILE\Saved Games\DCS\Liveries"
-  ${ElseIf} ${FileExists} "$PROFILE\Saved Games\DCS.openbeta"
+  ${ElseIf} ${FileExists} "$PROFILE\Saved Games\DCS"
     StrCpy $InstDir "$PROFILE\Saved Games\DCS.openbeta\Liveries"
   ${EndIf}
+  
+  ReadRegStr $ProgramFilesDir "HKCU" "SOFTWARE\Eagle Dynamics\DCS World OpenBeta" "Path"
+  ${If} "$ProgramFilesDir" == ""
+    ReadRegStr $ProgramFilesDir "HKCU" "SOFTWARE\Eagle Dynamics\DCS World" "Path"
+  ${EndIf}
+
   InitPluginsDir
   File "/oname=$PluginsDir\mig29flyby.wav" "mig29flyby.wav"
   File "/oname=$PluginsDir\rssplash.bmp" "rssplash.bmp"
@@ -102,53 +130,61 @@ Page custom nsDialogsPage nsDialogsPageLeave
 ; Old and unused livery folder names are OK to remain in the cleanup list. We want to reduce clutter for the user
 
 
-Section "Delete Red Star Liveries"
+SectionGroup "Clean Up Old Red Star Liveries"
+  Section "Red Star Bin"
     RMDir /r "$INSTDIR\RED STAR BIN"
+  SectionEnd
+  SectionGroup "RoughMets"
+  {%- for category, roughmet_filenames in roughmets.items() %}
+    Section "{{ category }}"
+    {%- for roughmet_filename in roughmet_filenames %}
+      Delete "$ProgramFilesDir\Bazar\TempTextures\{{ roughmet_filename }}"
+    {%- endfor %}
+    SectionEnd
+  {%- endfor %}
+  SectionGroupEnd
+  Section "Red Star Camo Liveries"
   {%- for livery in rs_liveries %}
-    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
-    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
-    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
-    {%- endfor %}
+  {%- include 'removal.j2' %}
   {%- endfor %}
+  SectionEnd
+  Section "Red Star Competitive Liveries"
   {%- for livery in rsc_liveries %}
-    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
-    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
-    RMDir /r "$INSTDIR\{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
-    {%- endfor %}
+  {%- include 'removal.j2' %}
   {%- endfor %}
-SectionEnd
+  SectionEnd
+SectionGroupEnd
 
-
-Section "!Red Star Required Assets"
+SectionGroup "!Red Star Required Assets"
+  Section "Red Star Bin (shared) Directory"
     SetOutPath $INSTDIR
     File /r "RED STAR BIN"
-SectionEnd
+  SectionEnd
+  SectionGroup "Red Star RoughMats"
+  {%- for category_name, roughmet_filenames in roughmets.items() %}
+    Section "{{ category_name }}"
+      SetOutPath "$ProgramFilesDir\Bazar\TempTextures\"
+    {%- for roughmet_filename in roughmet_filenames %}
+      File "RED STAR ROUGHMETS\{{ category_name }}\{{ roughmet_filename }}"
+    {%- endfor %}
+    SectionEnd
+  {%- endfor %}
+  SectionGroupEnd
+SectionGroupEnd
 
 SectionGroup "Red Star"
   {%- for livery in rs_liveries %}
-  Section "{{ livery["livery_base_dirname"] }}"
-    SetOutPath $INSTDIR\{{ livery["dcs_airframe_codename"] }}
-    File /r "{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
-    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
-    File /r "{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
-    {%- endfor %}
-  SectionEnd 
+  {%- include 'livery_section.j2' %}
   {%- endfor %}
 SectionGroupEnd
 
 SectionGroup "Red Star BLACK SQUADRON"
   {%- for livery in rsc_liveries %}
-  Section "{{ livery["livery_base_dirname"] }}"
-    SetOutPath $INSTDIR\{{ livery["dcs_airframe_codename"] }}
-    File /r "{{ livery["dcs_airframe_codename"] }}\{{ livery["livery_base_dirname"] }}"
-    {%- for pilot_dir in livery["livery_pilot_dirs"] %}
-    File /r "{{ livery["dcs_airframe_codename"] }}\{{ pilot_dir }}"
-    {%- endfor %}
-  SectionEnd 
+  {%- include 'livery_section.j2' %}
   {%- endfor %}
 SectionGroupEnd
 
-Section "!Modify Pilot Priority"
+Section "Modify Pilot Priority"
   SetOutPath "$PLUGINSDIR\NSISTemp"
   File /oname=$PLUGINSDIR\rs-liveries-pilot-priorities.ps1 rs-liveries-pilot-priorities.ps1
   ${PowerShellExecFileLog} '"$PLUGINSDIR\rs-liveries-pilot-priorities.ps1" -dcs_liveries_root_dir "$InstDir" -pilot "$PilotSelected"  '


### PR DESCRIPTION
RoughMets are being introduced. They are RoughMet textures that need to
reside in the install directory.

Python script changes:
* Better anchoring of livery directories in dir_pilot_and_livery_parser
* Minor comment changes
* Some variable name changes
* New dir_roughmet_parser function
 
Template changes
* Admin permissions required :cry: 
* New "browse" button for the DCS install dir. Autodetect through registry key
* Improve existing "pilot" dropdown by pre-selecting first option for click-through people
* Moved repetitive template segments into include-able files
* Better categorization
